### PR TITLE
fix/deletion-error

### DIFF
--- a/src/Components/Admin/Admin.js
+++ b/src/Components/Admin/Admin.js
@@ -38,11 +38,13 @@ class Admin extends React.Component {
    * If the page crashes then the user gets automatically logged out
    */
   componentWillUnmount() {
+    if(this.progressListener) this.progressListener();
+    if(this.workshopListener) this.workshopListener();
     this.props.database
       .auth()
       .signOut()
       .then(function () {
-        console.log("signed out");
+        console.log("auto signed out");
       })
       .catch(function (error) {
         console.log("error signing out");

--- a/src/Components/Admin/AdminAuth.js
+++ b/src/Components/Admin/AdminAuth.js
@@ -13,8 +13,6 @@ import NavBar from "../Layout/NavBar";
 /**
  * UI Component that contains two text fields to enter username and password as well as a submit button
  *
- * Author: Harsha Srikara
- * Date: 4/2/20
  */
 class AdminAuth extends React.Component {
   constructor(props) {

--- a/src/Components/Admin/AdminDashboard.js
+++ b/src/Components/Admin/AdminDashboard.js
@@ -131,7 +131,15 @@ class AdminDashboard extends React.Component {
   }
 
   deleteWorkshop(Workshop_ID) {
-    this.props.deleteWorkshop(Workshop_ID);
+    let workshopIndex = this.findWorkshopIndex(Workshop_ID);
+    let workshopArray = this.state.workshops;
+    workshopArray.splice(workshopIndex, 1);
+    this.setState({
+      viewWorkshop: false, //closes the respective workshop view before deletion 
+      workshops: workshopArray,
+    }, function() {
+      this.props.deleteWorkshop(Workshop_ID);
+    });
   }
 
   incrementLevel(Workshop_ID) {

--- a/src/Components/User/User.js
+++ b/src/Components/User/User.js
@@ -1,7 +1,7 @@
 import React from "react";
-import UserAuth from './UserAuth';
-import UserDash from './UserDash';
-import WorkshopLogin from './WorkshopLogin';
+import UserAuth from "./UserAuth";
+import UserDash from "./UserDash";
+import WorkshopLogin from "./WorkshopLogin";
 
 class User extends React.Component {
   constructor(props) {
@@ -12,7 +12,8 @@ class User extends React.Component {
       workshop_data: null,
       Level_Enabled: 0,
       dataLoaded: false,
-      Enabled: false,    
+      Enabled: false,
+      loginError: false,
     };
 
     this.authenticate = this.authenticate.bind(this);
@@ -23,120 +24,152 @@ class User extends React.Component {
     this.signOutUser = this.signOutUser.bind(this);
   }
 
-  componentWillUnmount()
-  {
-    if(this.progressListener)
-      this.progressListener();
+  componentWillUnmount() {
+    if (this.progressListener) this.progressListener();
+    this.props.database
+      .auth()
+      .signOut()
+      .then(function () {
+        console.log("auto signed out");
+      })
+      .catch(function (error) {
+        console.log("error signing out");
+      });
   }
 
   // contacts firestore and authenticates the user. Sets user data if user login works.
-  authenticate(email, password) 
-  {
-    if(this.props.database.currentUser !== undefined)
-      {
-        console.log(this.props.database.currentUser)
-        this.setState({
-          loggedIn: true
-        })
-      }
-    this.props.database.auth().signInWithEmailAndPassword(email, password).catch(err =>
-      {
-        console.log("Invalid Email or Password")
-      })
-    this.props.database.auth().onAuthStateChanged(user =>
-      {
-        if(user) // user is signed in
-        {
-          this.setState({
-            loggedIn: true
-          })
-        }
-      })
-      return this.props.database.currentUser !== undefined;
-  }
-
-  authenticateWorkshop(workshop)
-  {
-    this.props.database.firestore().collection('Workshop').doc(workshop).get().then(doc =>
-      {
-          if(!doc.exists)
-              return;
-          else
-          {
-            this.setState(
-            { 
-                workshop_data: doc.data(),
-                workshopID: workshop
-            }, this.getProgressData)
-          }
-      })
-      return false;
-  }
- 
-  signInWorkshop()
-  {
-    if(this.state.Enabled)
-      this.updateUserProgress(0);
-  }
-
-  getProgressData()
-  {
-    this.progressListener = this.props.database.firestore().collection('StudentsAtWorkshop').doc(this.state.workshopID)
-          .onSnapshot(snapshot =>
-          {
-              console.log(snapshot.data())
-              this.setState({
-                  Level_Enabled: snapshot.data().Level_Enabled,
-                  Enabled: snapshot.data().Enabled,
-                  dataLoaded: true
-              })
-          })
-  }
-
-updateUserProgress(progress)
-{
-  // BELOW IS CODE TO UPDATE IF PROGRESS STORES IN A MAP
-  this.props.database.firestore().collection('StudentsAtWorkshop').doc(this.state.workshopID).update({
-    ['testProgress.' + this.props.database.auth().currentUser.uid] : progress
-  }).then(() => {
-    console.log("updated")
-  })
-}
-
-signOutUser()
-  {
-    console.log('signing Out');
-    this.props.database.auth().signOut().then(() =>
-    {
+  authenticate(email, password) {
+    if (this.state.loginError) {
       this.setState({
-        loggedIn: false, //once authentication happens this will toggle to true
-        workshopID: null,
-        workshop_data: null,
-        Level_Enabled: 0,
-        dataLoaded: false,
-        Enabled: false,
+        loginError: false,
+      });
+    }
+    this.props.database
+      .auth()
+      .signInWithEmailAndPassword(email, password)
+      .catch((err) => {
+        this.setState({
+          loginError: true,
+        });
+        console.log("Invalid Email or Password");
+      });
+    this.props.database.auth().onAuthStateChanged((user) => {
+      if (user) {
+        // user is signed in
+        this.setState({
+          loggedIn: true,
+        });
+      }
+    });
+    return this.props.database.currentUser !== undefined;
+  }
+
+  authenticateWorkshop(workshop) {
+    if (this.state.loginError) {
+      this.setState({
+        loginError: false,
+      });
+    }
+    this.props.database
+      .firestore()
+      .collection("Workshop")
+      .doc(workshop)
+      .get()
+      .then((doc) => {
+        if (!doc.exists){
+          this.setState({
+            loginError: true,
+          });
+        }
+        else {
+          this.setState(
+            {
+              workshop_data: doc.data(),
+              workshopID: workshop,
+            },
+            this.getProgressData
+          );
+        }
+      });
+  }
+
+  signInWorkshop() {
+    if (this.state.Enabled) this.updateUserProgress(0);
+  }
+
+  getProgressData() {
+    this.progressListener = this.props.database
+      .firestore()
+      .collection("StudentsAtWorkshop")
+      .doc(this.state.workshopID)
+      .onSnapshot((snapshot) => {
+        console.log(snapshot.data());
+        this.setState({
+          Level_Enabled: snapshot.data().Level_Enabled,
+          Enabled: snapshot.data().Enabled,
+          dataLoaded: true,
+        });
+      });
+  }
+
+  updateUserProgress(progress) {
+    // BELOW IS CODE TO UPDATE IF PROGRESS STORES IN A MAP
+    this.props.database
+      .firestore()
+      .collection("StudentsAtWorkshop")
+      .doc(this.state.workshopID)
+      .update({
+        ["testProgress." +
+        this.props.database.auth().currentUser.uid]: progress,
       })
-    }).catch(err =>
-      {
-        console.log("error signing user out")
+      .then(() => {
+        console.log("updated");
+      });
+  }
+
+  signOutUser() {
+    console.log("signing Out");
+    this.props.database
+      .auth()
+      .signOut()
+      .then(() => {
+        this.setState({
+          loggedIn: false, //once authentication happens this will toggle to true
+          workshopID: null,
+          workshop_data: null,
+          Level_Enabled: 0,
+          dataLoaded: false,
+          Enabled: false,
+        });
       })
+      .catch((err) => {
+        console.log("error signing user out");
+      });
   }
 
   render() {
     return (
       <div>
-        {/* If the user is not logged in then it displays the <AdminAuth /> Component, if they are logged in it will display the <AdminDashboard /> Component */}
-        {/* <AdminAuth /> Component receives the authenticate function as props, AdminDashboard will eventually receive the data read back from firebase */}
         {this.state.loggedIn ? (
-          ( this.state.dataLoaded === false ? (
-          <WorkshopLogin authenticate = {this.authenticateWorkshop}/>
+          this.state.dataLoaded === false ? (
+            <WorkshopLogin
+              authenticate={this.authenticateWorkshop}
+              loginError={this.state.loginError}
+            />
           ) : (
-            <UserDash workshop_data = {this.state.workshop_data} updateUserProgress = {this.updateUserProgress} 
-            progressListener = {this.progressListener} Level_Enabled = {this.state.Level_Enabled} signOut = {this.signOutUser} />
-          )
+            <UserDash
+              workshop_data={this.state.workshop_data}
+              updateUserProgress={this.updateUserProgress}
+              progressListener={this.progressListener}
+              Level_Enabled={this.state.Level_Enabled}
+              signOut={this.signOutUser}
+            />
           )
         ) : (
-          <UserAuth authenticate={this.authenticate} />
+          <UserAuth
+            authenticate={this.authenticate}
+            loginError={this.state.loginError}
+          />
         )}
       </div>
     );

--- a/src/Components/User/UserAuth.js
+++ b/src/Components/User/UserAuth.js
@@ -24,6 +24,16 @@ class UserAuth extends React.Component {
     this.authenticate = this.authenticate.bind(this);
   }
 
+  componentDidUpdate(prevProps)
+  {
+      if(this.props.loginError !== prevProps.loginError)
+      {
+          this.setState({
+              loginError: this.props.loginError
+          })
+      }
+  }
+
   fillEmail(event) {
     this.setState({
       email: event.target.value
@@ -40,12 +50,7 @@ class UserAuth extends React.Component {
    * Calls the authenticate function passed in from <Admin /> with the username and password stored in state
    */
   authenticate() {
-    if(this.props.authenticate(this.state.email, this.state.password) === false)
-    {
-      this.setState({
-        loginError: true
-      })
-    }
+    this.props.authenticate(this.state.email, this.state.password);
   }
 
   render() {

--- a/src/Components/User/WorkshopLogin.js
+++ b/src/Components/User/WorkshopLogin.js
@@ -1,33 +1,43 @@
 import React from "react";
 import NavBar from "../Layout/NavBar";
-import {Button, InputGroup, Row, Col, FormControl, Container, Alert} from 'react-bootstrap';
+import {
+  Button,
+  InputGroup,
+  Row,
+  Col,
+  FormControl,
+  Container,
+  Alert,
+} from "react-bootstrap";
 
 class WorkshopLogin extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      workshopID: '',
-      loginError: false
+      workshopID: "",
+      loginError: false,
     };
 
     this.fillWorkshop = this.fillWorkshop.bind(this);
     this.authenticate = this.authenticate.bind(this);
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.loginError !== prevProps.loginError) {
+      this.setState({
+        loginError: this.props.loginError,
+      });
+    }
+  }
+
   fillWorkshop(event) {
     this.setState({
-      workshopID: event.target.value
+      workshopID: event.target.value,
     });
   }
 
-  authenticate()
-  {
-      if(this.props.authenticate(this.state.workshopID) === false)
-        {
-          this.setState({
-            loginError: true
-          })
-        }
+  authenticate() {
+    this.props.authenticate(this.state.workshopID);
   }
 
   render() {
@@ -36,9 +46,17 @@ class WorkshopLogin extends React.Component {
         <NavBar />
         <Container fluid>
           <div className="m-5 p-5 floating-icon">
-          {this.state.loginError ? (
-              <Alert variant="danger" onClose = {() => this.setState({loginError: false})} dismissible>Invalid Workshop ID</Alert>
-            ) : ("")}
+            {this.state.loginError ? (
+              <Alert
+                variant="danger"
+                onClose={() => this.setState({ loginError: false })}
+                dismissible
+              >
+                Invalid Workshop ID
+              </Alert>
+            ) : (
+              ""
+            )}
             <Row>
               {/* Username text field */}
               <Col xs={12} sm={12} md={10}>
@@ -57,7 +75,7 @@ class WorkshopLogin extends React.Component {
                 </InputGroup>
               </Col>
               <Col xs={12} sm={12} md={2}>
-                {/* The authenticate function here is the one defined in this Component and not the one passed in from <Admin /> */}
+                {/* The authenticate function here is the one defined in this Component and not the one passed in from <User /> */}
                 <Button onClick={this.authenticate} variant="success">
                   Login
                 </Button>


### PR DESCRIPTION
Lots of error handling
 - On workshop deletion will ensure that the local copy of the data is first removed to ensure that the front-end doesn't break.
 - Made login flow significantly more robust on both admin and user side
 - Incorrect username/password will pop up alert
 - Entering an invalid workshop name will pop up alert
 - Sometimes even when entering the correct login details/workshop name the alert would momentarily pop up, this no longer happens
 - Code for login flow is consistent between admin and user side now
 - Removes progress listeners when unmounting 